### PR TITLE
Refractor conditional statement for ls command

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,12 @@ fs.readFile(userHomeDir + '/.boxrc.json', 'utf8', async function(err, data) {
       if(l) {
         await getDetailedMessages(currentChannel, session)
       }
-      if(c) {
+      else if(c) {
         await getChannels();
       }
-      await getMessages(currentChannel, session)
+      else{
+        await getMessages(currentChannel, session)
+      }
     });
     
     program

--- a/index.js
+++ b/index.js
@@ -64,13 +64,11 @@ fs.readFile(userHomeDir + '/.boxrc.json', 'utf8', async function(err, data) {
     .option('-l', 'list ids, sender box and timestamp')
     .option('-c', 'list all box channels')
     .action(async ({l, c}) => {
-      if(l) {
+      if (l) {
         await getDetailedMessages(currentChannel, session)
-      }
-      else if(c) {
+      } else if (c) {
         await getChannels();
-      }
-      else{
+      } else {
         await getMessages(currentChannel, session)
       }
     });


### PR DESCRIPTION
# Issue
ls command falls through each command regardless of arguments given when the user requests to list all channels `box ls -c`.

#Solution
We need to rewrite the conditional statement with an `elseif` to only invoke the `await getChannels()` when the user commends `box ls -c`. 

Before:
```javascript
program
    .command('ls')
    .description('list ids in current box')
    .option('-l', 'list ids, sender box and timestamp')
    .option('-c', 'list all box channels')
    .action(async ({l, c}) => {
      if(l) {
        await getDetailedMessages(currentChannel, session)
      }
      if(c) {
        await getChannels();
      }
      await getMessages(currentChannel, session)
    });
```
After: 
```javascript
program
    .command('ls')
    .description('list ids in current box')
    .option('-l', 'list ids, sender box and timestamp')
    .option('-c', 'list all box channels')
    .action(async ({l, c}) => {
      if(l) {
        await getDetailedMessages(currentChannel, session)
      }
      else if(c) {
        await getChannels();
      }
      else{
        await getMessages(currentChannel, session)
      }
    });
```
# Additional Information
In the future, we should only allow users to list all channels once they have been authenticated(login or registered).