### PR TITLE
Thom/quit command fix

### DIFF
--- a/Controllers/ChannelController.js
+++ b/Controllers/ChannelController.js
@@ -70,6 +70,8 @@ export const connectToChannel = async (receiver, sender, session) => {
     .subscribe((status) => {
       if (status === "SUBSCRIBED") {
         console.log("You're in " + receiver + "'s box\n")
+      } else if (status === "CLOSED") { 
+        console.log("You have quit the session.")
       } else {
         throw new Error("The connection failed")
       }

--- a/index.js
+++ b/index.js
@@ -67,10 +67,12 @@ fs.readFile(userHomeDir + '/.boxrc.json', 'utf8', async function(err, data) {
       if(l) {
         await getDetailedMessages(currentChannel, session)
       }
-      if(c) {
+      else if(c) {
         await getChannels();
       }
-      await getMessages(currentChannel, session)
+      else{
+        await getMessages(currentChannel, session)
+      }
     });
     
     program


### PR DESCRIPTION
# Issue 
When the user runs :quit command in live chat, an error is logged to the console from the subscribe callback. 

```javascript
  const channel = supabase
    .channel('any')
    .on('postgres_changes', { event: '*', schema: 'public', table: 'message', filter: `receiver=eq.${receiver}` }, 
    (payload) => {
      console.log(payload.new.content)
    })
    .subscribe((status) => {
      if (status === "SUBSCRIBED") {
        console.log("You're in " + receiver + "'s box\n")
      } else {
        throw new Error("The connection failed")
      }
    })
```
# Solution 

We need to add an `else if` statement to catch when the status is equal to `CLOSED` in the subscribe callback.

```javascript
const channel = supabase
    .channel('any')
    .on('postgres_changes', { event: '*', schema: 'public', table: 'message', filter: `receiver=eq.${receiver}` }, 
    (payload) => {
      console.log(payload.new.content)
    })
    .subscribe((status) => {
      if (status === "SUBSCRIBED") {
        console.log("You're in " + receiver + "'s box\n")
      } else if (status === "CLOSED") { 
        console.log("You have quit the session.")
      } else {
        throw new Error("The connection failed")
      }
    })
```